### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/homebank/transaction_management/models.py
+++ b/homebank/transaction_management/models.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 
 # Create your models here.
 from homebank.transaction_management.managers import TransactionManager, CategoryManager
@@ -81,7 +81,7 @@ class Transaction(models.Model):
         transactions = Transaction.objects.for_user(self.user).filter(category__isnull=True)
 
         for transaction in transactions:
-            result = fuzz.WRatio(transaction.description, self.description)
+            result = fuzz.WRatio(transaction.description, self.description, score_cutoff=self.score_threshold)
 
             if result > self.score_threshold:
                 transaction.category = self.category

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ hiredis==1.0.1  # https://github.com/redis/hiredis-py
 unidecode==1.1.1 # https://pypi.org/project/Unidecode/
 python-dateutil~=2.8.1
 testfixtures~=6.14.1
-fuzzywuzzy==0.18.0
+rapidfuzz==0.9.1
 python-magic-bin==0.4.14
 libsass==0.20.0
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy